### PR TITLE
CICO-58997: Change Webhook API client interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ client.webhooks.list
 client.webhooks.create(params)
 client.webhooks.retrieve(uuid)
 client.webhooks.update(uuid, params)
-client.webhooks.destroy(uuid)
+client.webhooks.delete(uuid)
 client.webhooks.supporting_events
 client.webhooks.delivery_types
 ```

--- a/webhook/lib/snt/webhook/rest/webhooks.rb
+++ b/webhook/lib/snt/webhook/rest/webhooks.rb
@@ -6,8 +6,8 @@ module SNT
       class Webhooks < SNT::Webhook::REST::Base
         resource :webhook
 
-        def list
-          get(path)
+        def list(params = {})
+          get(path, params)
         end
 
         def create(params)
@@ -22,8 +22,8 @@ module SNT
           put(path(uuid), params)
         end
 
-        def destroy(uuid)
-          delete(path(uuid))
+        def delete(uuid)
+          super(path(uuid))
         end
 
         def supporting_events


### PR DESCRIPTION
Makes the following changes to the Webhook API client interface:
  * Adds params option to the list method.
  * Renames destroy method to delete.