### PR TITLE
CICO-84342: Params as hash for Faraday connection

### DIFF
--- a/webhook/lib/snt/webhook/connection.rb
+++ b/webhook/lib/snt/webhook/connection.rb
@@ -16,6 +16,8 @@ module SNT
       end
 
       def request(method, url, params: nil, body: nil, headers: nil)
+        body = body.to_h unless body.nil?
+
         response = connection.run_request(method, url, body, headers) do |request|
           request.params.update(params) unless params.nil?
         end


### PR DESCRIPTION
  - Cast permitted ActionController::Params to hash before sending to webhook IPC endpoint