### PR TITLE
CICO-97284: Fix - Lost RabbitMQ connection after restart MQ service by AWS

### DIFF
--- a/auth/lib/snt/auth/rpc.rb
+++ b/auth/lib/snt/auth/rpc.rb
@@ -15,7 +15,7 @@ module SNT
       def self.call(method, message, options = {})
         queue = options.delete(:queue) || 'api'
 
-        SneakersPacker.remote_call(
+        SneakersPacker.assert_connection_and_remote_call(
           "auth.#{queue}.rpc",
           {
             request_id: SecureRandom.uuid,

--- a/pms/lib/snt/pms/api/rpc.rb
+++ b/pms/lib/snt/pms/api/rpc.rb
@@ -17,7 +17,7 @@ module SNT
           def call(method, message, options = {})
             queue = options.delete(:queue) || 'api'
 
-            SneakersPacker.remote_call(
+            SneakersPacker.assert_connection_and_remote_call(
               "pms.#{queue}.rpc",
               {
                 request_id: SecureRandom.uuid,

--- a/report/lib/snt/report/rpc.rb
+++ b/report/lib/snt/report/rpc.rb
@@ -15,7 +15,7 @@ module SNT
       def self.call(method, message, options = {})
         queue = options.delete(:queue) || 'api'
 
-        SneakersPacker.remote_call(
+        SneakersPacker.assert_connection_and_remote_call(
           "report.#{queue}.rpc",
           {
             request_id: SecureRandom.uuid,


### PR DESCRIPTION
WHY:
- Lost RabbitMQ connection after restarting MQ service by AWS maintenance

WHAT:
- Delete the queue if it has empty consumers
- Set the rpc client object as nil if the queue is not present or it has 0 consumers,
- It will create a new dedicated rpc queue to process the message while generating the new rpc client