### PR TITLE
CICO-115220: Use Rails default logger in service modules 

### DIFF
--- a/core/lib/snt/core/mq/publisher.rb
+++ b/core/lib/snt/core/mq/publisher.rb
@@ -46,9 +46,6 @@ module SNT
         # @return [Boolean]
         #
         def publish!(msg, options = {})
-          if defined?(::OpenTracing) && ::OpenTracing.current_trace_object
-            msg = JSON.parse(msg).merge(headers: ::OpenTracing.current_trace_object).to_json
-          end
           broadcast(msg, options)
 
           # We must rescue all exceptions, so an issue with queuing system does not degrade the rest of the app
@@ -64,9 +61,6 @@ module SNT
         # @return [Boolean]
         #
         def publish(msg, options = {})
-          if defined?(::OpenTracing) && ::OpenTracing.current_trace_object
-            msg = JSON.parse(msg).merge(headers: ::OpenTracing.current_trace_object).to_json
-          end
           broadcast(msg, options)
 
           true

--- a/core/lib/snt/core/services/base.rb
+++ b/core/lib/snt/core/services/base.rb
@@ -98,7 +98,7 @@ module SNT
 
         # Initialize the logger with the class name
         def logger
-          @logger ||= Logging::Logger[self.class.name]
+          @logger ||= Rails.logger
         end
       end
     end


### PR DESCRIPTION
WHY:
- Upgraded apps are getting errors as the logging-rails gem is depricated

WHAT:
- Use Rails default logger in the service modules