### PR TITLE
CICO-122464: Modify the publisher to normalize the routing_key option

### DIFF
--- a/core/lib/snt/core/mq/publisher.rb
+++ b/core/lib/snt/core/mq/publisher.rb
@@ -85,6 +85,13 @@ module SNT
         # @param options [Hash] Possible options include exchange, exchange_options, to_queue, and routing_key
         #
         def broadcast(msg, options = {})
+          # If options[:routing_key] is provided, and it is a symbol, log a warning
+          # and convert it to a string
+          if options[:routing_key].is_a?(Symbol)
+            ::SNT::Core::MQ.logger.warn "Routing key is a symbol, converting to string: #{options[:routing_key]}"
+            options[:routing_key] = options[:routing_key].to_s
+          end
+
           # Threadsafe publish
           @mutex.synchronize do
             error_retry_count = 0

--- a/core/lib/snt/core/version.rb
+++ b/core/lib/snt/core/version.rb
@@ -1,3 +1,3 @@
 module SNT
-  VERSION = '3.0.5'.freeze
+  VERSION = '3.3.1'.freeze
 end


### PR DESCRIPTION
Sometimes our apps are senting symbols, but they should be string. This will prevent issues in Bunny and other dependent libaries.