### PR TITLE
CICO-98577: Ruby 3.1.6 upgrade (Ruby 3 keyword-arg + argument-delegation handling)

### DIFF
--- a/core/lib/snt/core/services/base.rb
+++ b/core/lib/snt/core/services/base.rb
@@ -10,8 +10,8 @@ module SNT
         end
 
         # Provide class level call method as convenience over calling new, then call
-        def self.call(*args, &block)
-          new(*args, &block).call
+        def self.call(...)
+          new(...).call
         end
 
         # @params

--- a/core/lib/snt/core/services/base.rb
+++ b/core/lib/snt/core/services/base.rb
@@ -66,14 +66,14 @@ module SNT
         # options [Hash] attributes:
         # - ignore_errors [boolean] Do not add other service's errors to this service's errors
         def call_service!(service_class, attributes, options = {})
-          merge_result!(service_class.new(attributes).call, options)
+          merge_result!(service_class.new(**attributes).call, options)
         end
 
         # Call another service by passing the class, its attributes, and options. If other service fails, ignore the errors by default.
         # options [Hash] attributes:
         # - ignore_errors [boolean] Do not add other service's errors to this service's errors
         def call_service(service_class, attributes, options = { ignore_errors: true })
-          merge_result(service_class.new(attributes).call, options)
+          merge_result(service_class.new(**attributes).call, options)
         end
 
         private

--- a/core/lib/snt/core/version.rb
+++ b/core/lib/snt/core/version.rb
@@ -1,3 +1,3 @@
 module SNT
-  VERSION = '3.0.4'.freeze
+  VERSION = '3.0.5'.freeze
 end

--- a/snt.gemspec
+++ b/snt.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.description = 'Stayntouch'
   s.homepage     = ''
 
-  s.required_ruby_version = '>= 2.1.7'
+  s.required_ruby_version = '>= 3.0.1'
 
   s.files        = Dir.glob('{bin,lib}/**/*') + %w(README.md)
   s.bindir        = 'bin'


### PR DESCRIPTION
## Summary
Preserves the **CICO-98577 Ruby 3.1.6 upgrade** work (Ruby 3 keyword-argument + argument-delegation
handling, required-ruby/version bump) as a PR. These commits lived on a fork's `master` (diverged from
upstream); opening them so they're tracked rather than stranded.

## ⚠️ Verify before merging
This work is from 2024 and the fleet is already on Ruby 3.1.x — **the upgrade may already be in upstream via
different commits.** Reviewers: check the diff for redundancy and **close if superseded**. Branch may need a
rebase onto current `master`.

## Test Plan
- [ ] Diff is not already covered by current `master`
- [ ] `bundle install` + gem build on Ruby 3.1.6

🤖 Generated with [Claude Code](https://claude.com/claude-code)