### PR TITLE
CICO-135748: Always restore the MDC and close the scope; drop the constant span_name

### DIFF
--- a/core/lib/snt/core/open_tracing/gem_ext.rb
+++ b/core/lib/snt/core/open_tracing/gem_ext.rb
@@ -17,23 +17,29 @@ module OpenTracing
   end
 
   # Creates a new active span based on a parent span if provided. if child_of is nil, it will create a new span and trace
+  #
+  # CICO-135748: the restore and the scope.close must run even when the block raises. Previously
+  # they sat after a bare `yield`, so any exception escaping the block left the four MDC keys
+  # pointing at the finished span and never closed the scope -- leaking it into whatever ran next on
+  # that thread. Unhandled exceptions are exactly the case where the trace context matters most.
   def self.start_span_with_logging(span_name, child_of = nil)
     scope = ::OpenTracing.start_active_span(span_name, child_of: child_of)
     span = scope.span
     original_mdc_trace = ::Logging.mdc['trace']
     original_mdc_parent_span = ::Logging.mdc['parent_span']
     original_mdc_span = ::Logging.mdc['span']
-    original_mdc_span_name = ::Logging.mdc['span_name']
     ::Logging.mdc['trace'] = span.context.trace_context.trace_id
     ::Logging.mdc['parent_span'] = span.context.trace_context.parent_id
     ::Logging.mdc['span'] = span.context.trace_context.id
-    ::Logging.mdc['span_name'] = span_name
-    yield scope
-    ::Logging.mdc['trace'] = original_mdc_trace
-    ::Logging.mdc['parent_span'] = original_mdc_parent_span
-    ::Logging.mdc['span'] = original_mdc_span
-    ::Logging.mdc['span_name'] = original_mdc_span_name
-    scope.close
+
+    begin
+      yield scope
+    ensure
+      ::Logging.mdc['trace'] = original_mdc_trace
+      ::Logging.mdc['parent_span'] = original_mdc_parent_span
+      ::Logging.mdc['span'] = original_mdc_span
+      scope.close
+    end
   end
 
   # Gets the current active span in current scope and returns a trace object based on that


### PR DESCRIPTION
## What

Two fixes in `core/lib/snt/core/open_tracing/gem_ext.rb`, split out of CICO-135742 because they live here rather than in the PMS — this gem is consumed by **`pms`, `rover-auth`, `rover-ifc` and `rover-webhook`**.

## 1. The scope and the MDC leaked when the block raised — a real bug

```ruby
::Logging.mdc['trace'] = span.context.trace_context.trace_id
...
yield scope                          # <-- bare yield
::Logging.mdc['trace'] = original_mdc_trace
...
scope.close                          # <-- never reached if the block raises
```

No `begin/ensure`. When the yielded block raised:

- the four MDC keys kept pointing at the **finished** span, so any later log line on that thread was attributed to the wrong trace;
- **`scope.close` never ran**, leaking the active scope onto the thread.

For a PMS HTTP request the MDC half is partly masked — `RequestContextMiddleware` clears the whole MDC in its own `ensure` — but that does **not** apply to the message-queue workers or to nested `start_span_with_logging` use, and nothing masks the leaked scope. Unhandled exceptions are precisely when trace context matters most, which is what makes this worth fixing rather than tidying.

## 2. `span_name` in the MDC was a constant, and a trap

The PMS passes the literal `"pms_request"` from `Tracing::TracerMiddleware` for every request, and this method copied it into `Logging.mdc['span_name']`. Measured on `logs-pms.api-*`: present on **99.84% of documents with cardinality 1**, ~27 bytes each, about **3 GB/day across production**.

Worse than the cost, it is misleading — it *looks* like the field naming the operation, so anything grouped by it puts 100% of traffic in one bucket while appearing authoritative. CICO-135742's field investigation hit exactly this.

The `span_name` argument still names the actual OpenTracing span, unchanged. Only the MDC copy is removed, and it is a **separate commit** so it can be dropped without touching fix 1.

## What to check before merging

**Confirm nothing filters on `mdc.span_name`** — a saved search, a dashboard, an alerting rule. That filter is equivalent to "all PMS requests" so it is unlikely to be load-bearing, but it is worth thirty seconds. Anything that does can use `kubernetes.app_name` instead, which carries the real signal.

## Verification — please read

**This repository has no test suite.** No `spec/` or `test/` directory, no CI configuration. So this change is **not covered by an automated test**; it was verified by reading, and the `begin/ensure` transformation is deliberately the smallest one that fixes it.

I did not add a harness in this PR because standing one up for a gem with none is a larger decision than this fix — but it is a reasonable follow-up and I'm happy to do it.

## Relationship to CICO-135742

That ticket's storage model assumed this ~3 GB/day saving would offset most of its own ~+7.9 GB/day. Because it lives in a different repo, **that offset was not realised there** — landing this is what makes 135742's net cost land where its ticket claimed.

Jira: CICO-135748 (epic CICO-135738)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
